### PR TITLE
stop the game from scrolling on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
 
       body.js {
         overflow: hidden;
+        position: fixed;
       }
 
       h1 {


### PR DESCRIPTION
at some point mobile safari and/or iOS changed such that dragging the tether around also caused the page to scroll up and down, which makes control seem a lot weirder. this PR restores the original behaviour of the viewport being fixed.